### PR TITLE
Create Session Check Endpoint

### DIFF
--- a/apps/server/src/controllers/auth/readSessionHandler/index.ts
+++ b/apps/server/src/controllers/auth/readSessionHandler/index.ts
@@ -1,0 +1,1 @@
+export { default } from './readSessionHandler'

--- a/apps/server/src/controllers/auth/readSessionHandler/readSessionHandler.ts
+++ b/apps/server/src/controllers/auth/readSessionHandler/readSessionHandler.ts
@@ -1,0 +1,60 @@
+import { ApiResponse } from '@shared/types/api'
+import { readSession } from '@/data/session'
+import { Request, Response } from 'express'
+import parseCookies from '@/utils/parseCookies'
+
+type PossibleCookies = {
+  craveCookie?: string
+}
+
+/**
+ * Route handler for processing session check requests.
+ *
+ * @param {Request} req - The Express request object,
+ * @param {Response} res - The Express response object used to send the response back to the client.
+ */
+export default async function readSessionHandler(
+  req: Request,
+  res: Response
+): Promise<Response<any, Record<string, any>>> {
+  try {
+    // Extract raw cookies from the request headers
+    const rawCookies = req.headers.cookie
+
+    // Check if cookies are present and the "craveCookie" is present
+    if (!rawCookies) {
+      const errorResponse: ApiResponse<null> = {
+        statusCode: 404,
+        success: false,
+        data: null,
+        message: 'Session not found',
+      }
+      return res.status(errorResponse.statusCode).json(errorResponse)
+    }
+
+    // Parse cookies into a key-value object for easier access
+    const cookies: PossibleCookies = parseCookies(rawCookies)
+
+    if (!cookies.craveCookie) {
+      const errorResponse: ApiResponse<null> = {
+        statusCode: 400,
+        success: true,
+        data: null,
+        message: 'Session not found',
+      }
+      return res.status(errorResponse.statusCode).json(errorResponse)
+    }
+
+    // Validate the session JWT/cookie
+    const response = await readSession(cookies.craveCookie)
+    return res.status(response.statusCode).json(response)
+  } catch (e) {
+    // Handle unexpected errors
+    const errorResponse: ApiResponse<undefined, undefined> = {
+      statusCode: 500,
+      success: false,
+      message: 'Something went wrong',
+    }
+    return res.status(500).json(errorResponse)
+  }
+}

--- a/apps/server/src/data/session/index.ts
+++ b/apps/server/src/data/session/index.ts
@@ -1,0 +1,1 @@
+export { default as readSession } from './readSession'

--- a/apps/server/src/data/session/readSession/index.ts
+++ b/apps/server/src/data/session/readSession/index.ts
@@ -1,0 +1,1 @@
+export { default } from './readSession'

--- a/apps/server/src/data/session/readSession/readSession.ts
+++ b/apps/server/src/data/session/readSession/readSession.ts
@@ -1,0 +1,60 @@
+import { ApiResponse } from '@shared/types/api'
+import { supabase } from '@/lib/supabase'
+import { UserDTO } from '@shared/types/user'
+import prisma from '@/lib/prisma'
+
+/**
+ * Verifies a session is valid and returns the user associated with it.
+ *
+ * @param {string} token - The session JWT
+ * @returns {Promise<ApiResponse<UserDTO | null, string>>} Response object containing success status, data/error message, and status code
+ */
+export default async function readSession(
+  token: string
+): Promise<ApiResponse<UserDTO | null>> {
+  try {
+    // Retrieve the user associated with the token from Supabase
+    const { data, error: supabaseError } = await supabase.auth.getUser(token)
+
+    // Handle potential Supabase auth errors
+    if (supabaseError) {
+      console.log(supabaseError.message)
+      throw new Error(`Database session read error`)
+    }
+
+    // Check if there's a user in the database with the userId from Supabase
+    const user: UserDTO | null = await prisma.user.findUnique({
+      where: {
+        id: data.user.id,
+      },
+    })
+
+    if (!user) {
+      return {
+        statusCode: 404,
+        success: false,
+        data: null,
+        message: 'No user found ',
+      }
+    }
+
+    // Return the user data in the response so it can be used after verifying the session
+    return {
+      statusCode: 200,
+      success: true,
+      data: user,
+      message: 'Session data present',
+    }
+  } catch (e) {
+    const errorMessage =
+      e instanceof Error
+        ? e.message
+        : 'Unexpected server error while reading session'
+    return {
+      statusCode: 500,
+      success: false,
+      message: errorMessage,
+      data: null,
+    }
+  }
+}

--- a/apps/server/src/routes/auth/index.ts
+++ b/apps/server/src/routes/auth/index.ts
@@ -1,13 +1,17 @@
+import express from 'express'
 import loginUserHandler from '@/controllers/auth/loginUserHandler'
 import passwordResetRequestHandler from '@/controllers/auth/passwordResetRequestHandler'
-import express from 'express'
+import readSessionHandler from '@/controllers/auth/readSessionHandler'
 
 const authRouter = express.Router()
 
 authRouter.use(express.json())
 
+// Session
 authRouter.post('/login', loginUserHandler)
+authRouter.get('/session', readSessionHandler)
 
+// User
 authRouter.post('/password-reset', passwordResetRequestHandler)
 
 export default authRouter

--- a/apps/server/src/utils/parseCookies/index.ts
+++ b/apps/server/src/utils/parseCookies/index.ts
@@ -1,0 +1,1 @@
+export { default } from './parseCookies'

--- a/apps/server/src/utils/parseCookies/parseCookies.ts
+++ b/apps/server/src/utils/parseCookies/parseCookies.ts
@@ -1,0 +1,22 @@
+/**
+ * Parses a raw cookie string into an object mapping cookie names to their values.
+ *
+ * @param {string} rawCookies - The raw cookie string from the header of a request.
+ * @returns {Record<string, string>} An object where each key is a cookie name and each value is the corresponding cookie value.
+ *
+ * @example
+ *
+ * const rawCookies = "fakeCookie=fakeValue; fakeCookie2=blah";
+ *
+ * const parsedCookies = parseCookies(rawCookies);
+ * // Result: { fakeCookie: "fakeValue", fakeCookie2: "blah" }
+ */
+export default function parseCookies(
+  rawCookies: string
+): Record<string, string> {
+  return Object.fromEntries(
+    rawCookies
+      .split('; ')
+      .map((cookie) => cookie.split('=').map(decodeURIComponent))
+  )
+}


### PR DESCRIPTION
## Description

This PR introduces a new endpoint that allows users to validate their session and retrieve the associated user data.

## Key Changes

- Created the `readSession` data function to validate a session JWT and fetch associated user information.

## New Endpoints
- `/auth/session` `GET` (Verifies the user's session token and returns the user data for the associated session)

### Sample Response (Session Found):
```json
{
    "statusCode": 200,
    "success": true,
    "data": {
        "id": "fake-uuid",
        "name": "John Doe",
        "email": "johndoe@email.com",
        "role": "EMPLOYEE",
        "isActive": true,
        "registrationDate": "2024-11-18T05:29:03.649Z"
    },
    "message": "Session data present"
}
```

### Sample Response (Session Not Found):
```json
{
    "statusCode": 404,
    "success": false,
    "data": null,
    "message": "Session not found"
}
```


## Related Issues
This PR will close #18
